### PR TITLE
Usunięte info o quescie który nie istnieje

### DIFF
--- a/docs/chapters/4.md
+++ b/docs/chapters/4.md
@@ -47,8 +47,6 @@ Grey mówi, że niektóre cenne przedmioty zostały zatopione w kopalni. Pod wod
 
 Fulcher, jeden z Cieni, opowiada nam o szczególnie niebezpiecznym bandycie — Cleaverze. Jeśli przyniesiemy mu piwo, będzie chciał opowiedzieć więcej. Powinniśmy już mieć piwo, więc mu je dajemy. Okazuje się, że Cleaver zabił jego brata długo przed pojawieniem się bariery. Idziemy do obozu Quentina, tam rozmawiamy z Gerretem i decydujemy o losie bandyty. Na koniec wracamy do Fulchera.
 
-> Uwaga: Po zabiciu Cleavera tracimy możliwość wykonania zadania z Siekaczem o zabiciu Cleavera w 5. rozdziale!
-
 ## Pakt z Tobem ##
 
 **Zleca: Tob**


### PR DESCRIPTION
W rozdziale 5 nie ma wzmianki o jakimkolwiek queście z Siekaczem i Cleaverem (a ściśle rzecz biorąc - w ogóle żadnym queście z Cleaverem). Szukając w skryptach nie znalazłem żadnego dialogu z siekaczem i cleaverem, generalnie siekacz chyba występuje tylko w kontekście questu z Salvadorem